### PR TITLE
Fix package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ascii-art",
+  "name": "ascii-image",
   "version": "3.0.0",
   "description": "Displays an image as ASCII art",
   "main": "ascii-image.js",


### PR DESCRIPTION
The package name was erroneously called `ascii-art`, when it should be `ascii-image`.